### PR TITLE
Add OneComp (Fujitsu) and QEP (NeurIPS'25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ This repo collects papers, documents, and codes about model quantization for any
 
 ### 2026
 
+- **[arXiv'26]** [OneComp: One-Line Revolution for Generative AI Model Compression](https://arxiv.org/abs/2603.28845). *Yuma Ichikawa et al.* [[Code](https://github.com/FujitsuResearch/OneCompression)]
+- **[NeurIPS'25]** [Quantization Error Propagation: Revisiting Layer-Wise Post-Training Quantization](https://openreview.net/forum?id=a3l3K9khbL). *Yamato Arai, Yuma Ichikawa.* [[Code](https://github.com/FujitsuResearch/OneCompression)]
+
 - [[ICLR](https://openreview.net/forum?id=7QZanjCD6M)] PT²-LLM: Post-Training Ternarization for Large Language Models [[code](https://github.com/XIANGLONGYAN/PT2-LLM)] [![GitHub stars](https://img.shields.io/github/stars/XIANGLONGYAN/PT2-LLM?style=social)](https://github.com/XIANGLONGYAN/PT2-LLM)
 - [[ICLR](https://openreview.net/forum?id=HD7tuVakmR)] Quant-dLLM: Post-Training Extreme Low-Bit Quantization for Diffusion Large Language Models
 - [[ICLR](https://openreview.net/forum?id=3AnRMvlVDw)] DVD-Quant: Data-free Video Diffusion Transformers Quantization


### PR DESCRIPTION
## Summary

This PR adds **OneComp** (Fujitsu Research, [arXiv:2603.28845](https://arxiv.org/abs/2603.28845)) and its accompanying NeurIPS 2025 paper **QEP** to this awesome list.

OneComp is an open-source, Apache-2.0 licensed post-training quantization (PTQ) framework for LLMs that unifies several recent research directions behind a single `Runner.auto_run()` API:

- **QEP** (Quantization Error Propagation, NeurIPS 2025) — layer-wise PTQ with propagated error compensation.
- **AutoBit** — ILP-based mixed-precision bitwidth assignment derived from available VRAM.
- **JointQ** — joint weight–scale optimization (group-wise 4-bit, etc.).
- **Rotation preprocessing** — SpinQuant/OstQuant-style learned rotations absorbed into weights, with online Hadamard hooks at load time.
- **LoRA SFT post-process** — accuracy recovery / knowledge injection after quantization.
- **vLLM plugin** — first-class DBF & Mixed-GPTQ serving of OneComp checkpoints.

Verified on Llama (TinyLlama / Llama-2 / Llama-3) and Qwen3 (0.6B — 32B). PyPI: `pip install onecomp`.

Links:
- Repo: https://github.com/FujitsuResearch/OneCompression
- Paper (OneComp): https://arxiv.org/abs/2603.28845
- Paper (QEP, NeurIPS 2025): https://openreview.net/forum?id=a3l3K9khbL
- Docs: https://FujitsuResearch.github.io/OneCompression/

Happy to adjust section placement, wording, or formatting to better match the list's conventions — thanks for maintaining this resource!
