### PR TITLE
Add EdgeRazor to 2026 papers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ This repo collects papers, documents, and codes about model quantization for any
 
 ### 2026
 
+- [[arXiv](https://arxiv.org/abs/2605.04062)] EdgeRazor: A Lightweight Framework for Large Language Models via Mixed-Precision Quantization-Aware Distillation [[code](https://github.com/zhangsq-nju/EdgeRazor)] [![GitHub stars](https://img.shields.io/github/stars/zhangsq-nju/EdgeRazor?style=social)](https://github.com/zhangsq-nju/EdgeRazor)
 - [[ICLR](https://openreview.net/forum?id=7QZanjCD6M)] PT²-LLM: Post-Training Ternarization for Large Language Models [[code](https://github.com/XIANGLONGYAN/PT2-LLM)] [![GitHub stars](https://img.shields.io/github/stars/XIANGLONGYAN/PT2-LLM?style=social)](https://github.com/XIANGLONGYAN/PT2-LLM)
 - [[ICLR](https://openreview.net/forum?id=HD7tuVakmR)] Quant-dLLM: Post-Training Extreme Low-Bit Quantization for Diffusion Large Language Models
 - [[ICLR](https://openreview.net/forum?id=3AnRMvlVDw)] DVD-Quant: Data-free Video Diffusion Transformers Quantization


### PR DESCRIPTION
Hello,

Thank you for maintaining such a well-curated list of papers!

We are proposing **EdgeRazor**, a lightweight framework that compresses LLMs into flexible low-bit formats, achieving state-of-the-art performance in the sub-4-bit regime to facilitate resilient edge deployment. It supports **base**, **instruct**, and **multimodal LLMs**. We hope this would be a valuable addition to the [Papers-2026](https://github.com/Efficient-ML/Awesome-Model-Quantization#2026) section.

- **Paper**: https://arxiv.org/abs/2605.04062
- **Code**: https://github.com/zhangsq-nju/EdgeRazor
- **Model**: https://huggingface.co/collections/zhangsq-nju/edgerazor-nbit
- **Playground**: https://huggingface.co/spaces/zhangsq-nju/EdgeRazor-PlayGround

Thanks very much for your time and consideration!

Best regards, 
Shuhao Zhang